### PR TITLE
Python 3.13 지원

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: --release -o dist -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        args: --release -o dist -i 3.7 3.8 3.9 3.10 3.11 3.12 pypy3.10
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         manylinux: 2_28
         command: build
-        args: --release --sdist -o dist --find-interpreter
+        args: --release --sdist -o dist -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.10
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
@@ -26,7 +26,7 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --find-interpreter
+        args: --release -o dist -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.10
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
@@ -40,7 +40,7 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --target universal2-apple-darwin --find-interpreter
+        args: --release -o dist --target universal2-apple-darwin -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.10
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: --release -o dist --universal2 --find-interpreter
+        args: --release -o dist --target universal2-apple-darwin --find-interpreter
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: PyO3/maturin-action@v1
       with:
-        manylinux: 2_28
+        manylinux: auto
         command: build
         args: --release --sdist -o dist -i 3.7 3.8 3.9 3.10 3.11 3.12 3.13 pypy3.10
     - name: Upload wheels

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: PyO3/maturin-action@v1
       with:
-        manylinux: auto
+        manylinux: 2_28
         command: build
         args: --release --sdist -o dist --find-interpreter
     - name: Upload wheels

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ name = "tossicat"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
+pyo3 = { version = "0.22.6", features = ["extension-module"] }
 tossicat = "0.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
 
 [project]
 name = "tossicat-python"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,12 @@ pub fn postfix(word: &str, tossi: &str) -> PyResult<String> {
 pub fn modify_sentence(sentence: &str) -> PyResult<String> {
     match ::tossicat::modify_sentence(sentence) {
         Ok(result) => Ok(result),
-        Err(error) => {
-            Err(PyValueError::new_err(format!("{}",error)))
-        }
+        Err(error) => Err(PyValueError::new_err(format!("{}", error))),
     }
 }
 
 #[pymodule]
-fn tossicat(_py: Python, m: &PyModule) -> PyResult<()> {
+fn tossicat(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(transform, m)?)?;
     m.add_function(wrap_pyfunction!(postfix, m)?)?;
     m.add_function(wrap_pyfunction!(modify_sentence, m)?)?;


### PR DESCRIPTION
- fix #1
- [PyO3 0.22.0 이후](https://github.com/PyO3/pyo3/blob/main/CHANGELOG.md#0220---2024-06-24)부터 Python 3.13을 지원하는 관계로 최신 버전으로 올렸습니다.
- 이에 따라 `#[pymodule]` 사용법이 바뀌어 같이 대응합니다.
- Python 3.13 wheel을 생성할 수 있다는 것은 확인했습니다만 코드가 정상적으로 동작하는지, ~~GitHub Actions 상에서 3.13의 interpreter를 찾을 수 있는지는 확인되지 않았습니다.~~
- manylinux 버전을 올리면 `--find-interpreter` 로도 Python 3.13이 찾아질줄 알았는데 아니었습니다. 직접 지정해주는 방식으로 변경하였습니다.
- manylinux 버전을 올리려다보니 maturin도 최신버전을 지원하게 변경하게 되었습니다.
- 결과적으로 manylinux 버전은 안 올려도 되어서 `auto`로 롤백했습니다.
- Windows runner는 아직 Python 3.13을 기본지원하지 않아서 제외했습니다. Ref: https://github.com/PyO3/maturin-action/issues/292
- macOS용 CLI build 옵션의 이름이 maturin 버전이 올라가면서 바뀌어서 대응했습니다.